### PR TITLE
npe2 conversion (napari plugin engine 2)

### DIFF
--- a/napari_tiff/napari.yaml
+++ b/napari_tiff/napari.yaml
@@ -8,5 +8,6 @@ contributions:
   readers:
   - command: napari-tiff.get_reader
     filename_patterns:
-    - '*zip'
+    - '*.tiff'
+    - '*.tif'
     accepts_directories: true

--- a/napari_tiff/napari.yaml
+++ b/napari_tiff/napari.yaml
@@ -1,0 +1,12 @@
+name: napari-tiff
+schema_version: 0.2.0
+contributions:
+  commands:
+  - id: napari-tiff.get_reader
+    title: Get Reader
+    python_name: napari_tiff.napari_tiff_reader:napari_get_reader
+  readers:
+  - command: napari-tiff.get_reader
+    filename_patterns:
+    - '*zip'
+    accepts_directories: true

--- a/napari_tiff/napari_tiff_reader.py
+++ b/napari_tiff/napari_tiff_reader.py
@@ -12,7 +12,6 @@ https://napari.org/docs/plugins/for_plugin_developers.html
 from typing import List, Optional, Union, Any, Tuple, Dict, Callable
 
 import numpy
-from napari_plugin_engine import napari_hook_implementation
 from tifffile import TiffFile, TiffSequence, TIFF
 from vispy.color import Colormap
 
@@ -21,7 +20,6 @@ PathLike = Union[str, List[str]]
 ReaderFunction = Callable[[PathLike], List[LayerData]]
 
 
-@napari_hook_implementation
 def napari_get_reader(path: PathLike) -> Optional[ReaderFunction]:
     """Implements napari_get_reader hook specification.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 imagecodecs
-napari-plugin-engine>=0.1.4
 numpy
 tifffile>=2020.5.7
 vispy


### PR DESCRIPTION
Migration to the new napari plugin engine 2 spec, see https://napari.org/stable/plugins/npe2_migration_guide.html#migrating-using-the-npe2-command-line-tool