### PR TITLE
Plugin reader accepts zipped folders of tiff images, update napari.yaml

### DIFF
--- a/napari_tiff/napari.yaml
+++ b/napari_tiff/napari.yaml
@@ -10,4 +10,5 @@ contributions:
     filename_patterns:
     - '*.tiff'
     - '*.tif'
+    - '*.zip'
     accepts_directories: true


### PR DESCRIPTION
I forgot there was a `zip_reader` function in `napari_tiff_reader.py`. Adding `*.zip` to the list of accepted filenames.