### PR TITLE
Update test and deploy workflow

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,73 +1,84 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflow:
+# - runs tests on pull requests
+# - runs tests on pushing to main
+# - if it's a tag push and the tag starts with v, and if the tests pass,
+#   deploys to PyPI using Trusted Publishers:
+#   https://docs.pypi.org/trusted-publishers/
+name: test-and-deploy
 
-name: tests
-
-on: push
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
-  ubuntu-latest:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools tox tox-gh-actions
-      - name: Test with tox
-        run: tox
-      - name: Coverage
-        uses: codecov/codecov-action@v1
-
-  # minimizing matrix by only testing 3.6 on mac & windows
-  mac-win:
-    name: ${{ matrix.platform }} (3.6)
+  test:
+    name: ${{ matrix.platform }} py${{ matrix.python }}
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
-        platform: [macos-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+        # test spec-0 earliest and latest Python versions
+        # https://scientific-python.org/specs/spec-0000/
+        python: ["3.10", "3.12"]
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python-version }}
+
+      # these libraries enable testing Qt on Linux
+      - uses: tlambert03/setup-qt-libs@v1
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools tox tox-gh-actions
+          python -m pip install setuptools tox tox-gh-actions
+          # python -m pip install .[all,testing]  # use when adding test deps
+          python -m pip install .
+
       - name: Test with tox
         run: tox
-        env:
-          PLATFORM: ${{ matrix.platform }}
+
+      - name: Coverage
+        uses: codecov/codecov-action@v1
+        if: runner.os == 'Linux' && matrix.python == '3.11'
 
   deploy:
-    needs: [ubuntu-latest, mac-win]
+    needs: [test]
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags')
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U setuptools setuptools_scm wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
+          python -m pip install setuptools setuptools_scm build wheel
+
+      - name: Build
         run: |
           git tag
+          # python -m build  # change to this when updating to pyproject.toml
           python setup.py sdist bdist_wheel
-          twine upload dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-actions-pypi-publish@release/v1


### PR DESCRIPTION
- Update to more recent Python and actions versions for test section
- Update build and publish to use PyPI's trusted publishers mechanism

Some changes need to wait until #13 is closed, but I have left comments where
that needs to happen.
