### PR TITLE
Fix typo in PyPA action for PyPI release

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -79,7 +79,7 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-actions-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This should fix the failing deploy step. I've now copy-pasted from the napari
repo so it should be good! 😅
