### PR TITLE
Add specific tests for ometiff, imagej, and regular tiff file formats

### DIFF
--- a/napari_tiff/_tests/test_tiff_reader.py
+++ b/napari_tiff/_tests/test_tiff_reader.py
@@ -31,7 +31,7 @@ def example_data_imagej(tmp_path, original_data):
 
 def example_data_ometiff(tmp_path, original_data):
     example_data_filepath = str(tmp_path / "example_data_ometiff.ome.tif")
-    tifffile.imwrite(example_data_filepath, original_data, imagej=True)
+    tifffile.imwrite(example_data_filepath, original_data, imagej=False)
     return tifffile.TiffFile(example_data_filepath)
 
 

--- a/napari_tiff/_tests/test_tiff_reader.py
+++ b/napari_tiff/_tests/test_tiff_reader.py
@@ -12,13 +12,25 @@ import tifffile
 
 
 def example_data_filepath(tmp_path, original_data):
-    example_data_filepath = str(tmp_path / "myfile.tif")
-    tifffile.imwrite(example_data_filepath, original_data)
+    example_data_filepath = str(tmp_path / "example_data_filepath.tif")
+    tifffile.imwrite(example_data_filepath, original_data, imagej=False)
     return example_data_filepath
 
 
 def example_data_tiff(tmp_path, original_data):
-    example_data_filepath = str(tmp_path / "myfile.tif")
+    example_data_filepath = str(tmp_path / "example_data_tiff.tif")
+    tifffile.imwrite(example_data_filepath, original_data, imagej=False)
+    return tifffile.TiffFile(example_data_filepath)
+
+
+def example_data_imagej(tmp_path, original_data):
+    example_data_filepath = str(tmp_path / "example_data_imagej.tif")
+    tifffile.imwrite(example_data_filepath, original_data, imagej=True)
+    return tifffile.TiffFile(example_data_filepath)
+
+
+def example_data_ometiff(tmp_path, original_data):
+    example_data_filepath = str(tmp_path / "example_data_ometiff.ome.tif")
     tifffile.imwrite(example_data_filepath, original_data, imagej=True)
     return tifffile.TiffFile(example_data_filepath)
 
@@ -67,8 +79,9 @@ def test_reader(tmp_path, data_fixture, original_data):
 
 @pytest.mark.parametrize("reader, data_fixture, original_data", [
     (imagecodecs_reader, example_data_filepath, np.random.random((20, 20))),
-    (imagej_reader, example_data_tiff,  np.random.randint(0, 255, size=(20, 20)).astype(np.uint8)),
+    (imagej_reader, example_data_imagej,  np.random.randint(0, 255, size=(20, 20)).astype(np.uint8)),
     (tifffile_reader, example_data_tiff, np.random.randint(0, 255, size=(20, 20)).astype(np.uint8)),
+    (tifffile_reader, example_data_ometiff, np.random.randint(0, 255, size=(20, 20)).astype(np.uint8)),
     (zip_reader, example_data_zipped, np.random.random((20, 20))),
     ])
 def test_all_readers(reader, data_fixture, original_data, tmp_path):


### PR DESCRIPTION
These tests just check that the reader can load the data, they don't test any metadata from the file(s).