### PR TITLE
Provide extra metadata to napari layer as dictionary

### DIFF
--- a/napari_tiff/_tests/test_tiff_metadata.py
+++ b/napari_tiff/_tests/test_tiff_metadata.py
@@ -1,0 +1,58 @@
+import numpy
+import pytest
+from tifffile import imwrite, TiffFile
+
+from napari_tiff.napari_tiff_reader import imagej_reader
+
+
+@pytest.fixture(scope="session")
+def imagej_hyperstack_image(tmp_path_factory):
+    """ImageJ hyperstack tiff image.
+
+    Write a 10 fps time series of volumes with xyz voxel size 2.6755x2.6755x3.9474
+    micron^3 to an ImageJ hyperstack formatted TIFF file:
+    """
+    filename = tmp_path_factory.mktemp("data") / "imagej_hyperstack.tif"
+
+    volume = numpy.random.randn(6, 57, 256, 256).astype('float32')
+    image_labels = [f'{i}' for i in range(volume.shape[0] * volume.shape[1])]
+    metadata = {
+            'spacing': 3.947368,
+            'unit': 'um',
+            'finterval': 1/10,
+            'fps': 10.0,
+            'axes': 'TZYX',
+            'Labels': image_labels,
+        }
+    imwrite(
+        filename,
+        volume,
+        imagej=True,
+        resolution=(1./2.6755, 1./2.6755),
+        metadata=metadata,
+    )
+    return (filename, metadata)
+
+
+def test_imagej_hyperstack_metadata(imagej_hyperstack_image):
+    """Test metadata from imagej hyperstack tiff is passed to napari layer."""
+    imagej_hyperstack_filename, expected_metadata = imagej_hyperstack_image
+
+    with TiffFile(imagej_hyperstack_filename) as tif:
+        layer_data_list = imagej_reader(tif)
+
+    assert isinstance(layer_data_list, list) and len(layer_data_list) > 0
+    layer_data_tuple = layer_data_list[0]
+    assert isinstance(layer_data_tuple, tuple) and len(layer_data_tuple) == 3
+
+    napari_layer_metadata = layer_data_tuple[1]
+    assert napari_layer_metadata.get('scale') == (1.0, 3.947368, 2.675500000484335, 2.675500000484335)
+    assert layer_data_tuple[0].shape == (6, 57, 256, 256)  # image volume shape
+
+    napari_layer_imagej_metadata = napari_layer_metadata.get('metadata').get('imagej_metadata')
+    assert napari_layer_imagej_metadata.get('slices') == 57  # calculated automatically when file is written
+    assert napari_layer_imagej_metadata.get('frames') == 6   # calculated automatically when file is written
+    expected_metadata.pop('axes')  # 'axes' is stored as a tiff series attribute, not in the imagej_metadata property
+    for (key, val) in expected_metadata.items():
+        assert key in napari_layer_imagej_metadata
+        assert napari_layer_imagej_metadata.get(key) == val

--- a/napari_tiff/napari_tiff_reader.py
+++ b/napari_tiff/napari_tiff_reader.py
@@ -12,7 +12,7 @@ https://napari.org/docs/plugins/for_plugin_developers.html
 from typing import List, Optional, Union, Any, Tuple, Dict, Callable
 
 import numpy
-from tifffile import TiffFile, TiffSequence, TIFF
+from tifffile import TiffFile, TiffSequence, TIFF, xml2dict
 from vispy.color import Colormap
 
 LayerData = Union[Tuple[Any], Tuple[Any, Dict], Tuple[Any, Dict, str]]
@@ -71,7 +71,7 @@ def zip_reader(path: PathLike) -> List[LayerData]:
     return [(data, {}, 'image')]
 
 
-def tifffile_reader(tif):
+def tifffile_reader(tif: TiffFile):
     """Return napari LayerData from largest image series in TIFF file."""
     # TODO: fix (u)int32/64
     # TODO: handle complex
@@ -199,6 +199,8 @@ def tifffile_reader(tif):
         if channel_axis is not None and shape[channel_axis] > 1:
             contrast_limits = [contrast_limits] * shape[channel_axis]
 
+    metadata = get_tiff_metadata(tif)
+
     kwargs = dict(
         rgb=rgb,
         channel_axis=channel_axis,
@@ -208,11 +210,12 @@ def tifffile_reader(tif):
         contrast_limits=contrast_limits,
         blending=blending,
         visible=visible,
+        metadata=metadata,
     )
     return [(data, kwargs, 'image')]
 
 
-def imagej_reader(tif):
+def imagej_reader(tif: TiffFile):
     """Return napari LayerData from ImageJ hyperstack."""
     # TODO: ROI overlays
     ijmeta = tif.imagej_metadata
@@ -289,6 +292,8 @@ def imagej_reader(tif):
     else:
         scale = tuple(scale.get(x, 1.0) for x in axes if x not in 'CS')
 
+    metadata = get_tiff_metadata(tif)
+
     kwargs = dict(
         rgb=rgb,
         channel_axis=channel_axis,
@@ -298,14 +303,33 @@ def imagej_reader(tif):
         contrast_limits=contrast_limits,
         blending=blending,
         visible=visible,
+        metadata=metadata,
     )
     return [(data, kwargs, 'image')]
 
 
-def imagecodecs_reader(path):
+def imagecodecs_reader(path: PathLike):
     """Return napari LayerData from first page in TIFF file."""
     from imagecodecs import imread
     return [(imread(path), {}, 'image')]
+
+
+def get_tiff_metadata(tif: TiffFile) -> dict[str, Any]:
+    """Return any non-empty tif metadata properties as a dictionary."""
+    metadata_dict = {}
+    empty_metadata_values = [None, '', (), []]
+    for name in dir(tif.__class__):
+        obj = getattr(tif.__class__, name)
+        if isinstance(obj, property) and 'metadata' in name:
+            metadata_value = obj.__get__(tif)
+            if metadata_value not in empty_metadata_values:
+                if isinstance(metadata_value, str):
+                    try:
+                        metadata_value = xml2dict(metadata_value)
+                    except Exception:
+                        pass
+                metadata_dict[name] = metadata_value
+    return metadata_dict
 
 
 def alpha_colormap(bitspersample=8, samples=4):

--- a/napari_tiff/napari_tiff_reader.py
+++ b/napari_tiff/napari_tiff_reader.py
@@ -199,7 +199,7 @@ def tifffile_reader(tif: TiffFile):
         if channel_axis is not None and shape[channel_axis] > 1:
             contrast_limits = [contrast_limits] * shape[channel_axis]
 
-    metadata = get_tiff_metadata(tif)
+    metadata_dict = get_tiff_metadata(tif)
 
     kwargs = dict(
         rgb=rgb,
@@ -210,7 +210,7 @@ def tifffile_reader(tif: TiffFile):
         contrast_limits=contrast_limits,
         blending=blending,
         visible=visible,
-        metadata=metadata,
+        metadata=metadata_dict,
     )
     return [(data, kwargs, 'image')]
 
@@ -292,7 +292,7 @@ def imagej_reader(tif: TiffFile):
     else:
         scale = tuple(scale.get(x, 1.0) for x in axes if x not in 'CS')
 
-    metadata = get_tiff_metadata(tif)
+    metadata_dict = get_tiff_metadata(tif)
 
     kwargs = dict(
         rgb=rgb,
@@ -303,7 +303,7 @@ def imagej_reader(tif: TiffFile):
         contrast_limits=contrast_limits,
         blending=blending,
         visible=visible,
-        metadata=metadata,
+        metadata=metadata_dict,
     )
     return [(data, kwargs, 'image')]
 
@@ -320,9 +320,10 @@ def get_tiff_metadata(tif: TiffFile) -> dict[str, Any]:
     empty_metadata_values = [None, '', (), []]
     for name in dir(tif.__class__):
         obj = getattr(tif.__class__, name)
-        if isinstance(obj, property) and 'metadata' in name:
+        if 'metadata' in name:
             metadata_value = obj.__get__(tif)
             if metadata_value not in empty_metadata_values:
+                print(metadata_value)
                 if isinstance(metadata_value, str):
                     try:
                         metadata_value = xml2dict(metadata_value)


### PR DESCRIPTION
This PR searches for all *`_metadata`  attributes found in the tifffile python object, and puts them in a dictionary that is passed into the napari layer.

Napari layer objects have a `metadata` attribute, which can hold a dictionary. Napari doesn't actually *do* anything with this dictionary, but it does get stored in the layer right beside the actual data, so it is possible for the user to look up the metadata (and possibly do something with it themselves later on).

TiffFile objects have a number of *`_metadata` attributes (for any given case, most will return None or an empty list/tuple): 
* andor_metadata
* astrotiff_metadata
* eer_metadata
* epics_metadata
* fei_metadata
* fluoview_metadata
* gdal_metadata
* gdal_structural_metadata
* geotiff_metadata
* imagej_metadata
* indica_metadata
* lsm_metadata
* mdgel_metadata
* metaseries_metadata
* micromanager_metadata
* nih_metadata
* ome_metadata
* philips_metadata
* pilatus_metadata
* scanimage_metadata
* scn_metadata
* sem_metadata
* shaped_metadata
* sis_metadata
* stk_metadata
* streak_metadata
* tvips_metadata

Context: we've been discussing ome-tiff files and their related metadata. Seeing just how many other types of metadata could potentially be stored makes me think that a more generic solution like this one would be preferable to individually checking for 27 different types of possible metadata.