### PR TITLE
Update pyproject.toml, simplify optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,9 @@ dependencies = [
 
 [project.optional-dependencies]
 testing = [
-   'pytest',
-]
-
-dev = [
-   'tox',
    'build',
+   'pytest',
+   'tox',
 ]
 
 [tools.setuptools]


### PR DESCRIPTION
For developers, it is now sufficient to do: `pip install -e ".[testing]"`

Previously, this required: `pip install -e ".[testing, dev]"`, so it was easier to accidentally forget to add all required dependencies to your local development environments.