### PR TITLE
Name custom colormaps for photometric PALETTE

### DIFF
--- a/napari_tiff/napari_tiff_colormaps.py
+++ b/napari_tiff/napari_tiff_colormaps.py
@@ -1,5 +1,7 @@
 import numpy
 
+CUSTOM_COLORMAPS = {}  # CUSTOM_COLORMAPS[colormap_hash] = colormap_name
+
 
 def alpha_colormap(bitspersample=8, samples=4):
     """Return Alpha colormap."""

--- a/napari_tiff/napari_tiff_metadata.py
+++ b/napari_tiff/napari_tiff_metadata.py
@@ -145,12 +145,14 @@ def get_tiff_metadata(tif: TiffFile) -> dict[str, Any]:
 
         if page.photometric == PHOTOMETRIC.PALETTE and page.colormap is not None:
             # PALETTE
-            colormap = page.colormap
-            if numpy.max(colormap) > 255:
-                colormap = colormap / 65535.0
+            colormap_values = page.colormap
+            if numpy.max(colormap_values) > 255:
+                colormap_values = colormap_values / 65535.0
             else:
-                colormap = colormap / 255.0
-            colormap = colormap.astype("float32").T
+                colormap_values = colormap_values / 255.0
+            colormap_values = colormap_values.astype("float32").T
+            colormap = {"name": "PALETTE",  "colors": colormap_values}
+
 
     if colormap is None and page.photometric == PHOTOMETRIC.MINISWHITE:
         # MINISWHITE

--- a/napari_tiff/napari_tiff_metadata.py
+++ b/napari_tiff/napari_tiff_metadata.py
@@ -3,7 +3,7 @@ from typing import Any
 import numpy
 from tifffile import PHOTOMETRIC, TiffFile, xml2dict
 
-from napari_tiff.napari_tiff_colormaps import alpha_colormap, int_to_rgba
+from napari_tiff.napari_tiff_colormaps import alpha_colormap, int_to_rgba, CUSTOM_COLORMAPS
 
 
 def get_metadata(tif: TiffFile) -> dict[str, Any]:
@@ -151,8 +151,14 @@ def get_tiff_metadata(tif: TiffFile) -> dict[str, Any]:
             else:
                 colormap_values = colormap_values / 255.0
             colormap_values = colormap_values.astype("float32").T
-            colormap = {"name": "PALETTE",  "colors": colormap_values}
-
+            # set up custom colormap
+            colormap_hash = hash(tuple(tuple(x) for x in colormap_values))
+            if colormap_hash in CUSTOM_COLORMAPS:
+                colormap_name = CUSTOM_COLORMAPS[colormap_hash]
+            else:
+                colormap_name = "PALETTE: " + str(colormap_hash)
+                CUSTOM_COLORMAPS[colormap_hash] = colormap_name
+            colormap = {"name": colormap_name,  "colors": colormap_values}
 
     if colormap is None and page.photometric == PHOTOMETRIC.MINISWHITE:
         # MINISWHITE


### PR DESCRIPTION
Closes https://github.com/napari/napari-tiff/issues/32

Naming the custom colormap with a dictionary value avoids duplicating custom colormaps in the napari colormap dropdown list. Otherwise, we get a new (duplicate) colormap *every time* a photometric PALETTE tiff image is opened.
