### PR TITLE
Fix for zarr v3 compatibility

### DIFF
--- a/napari_tiff/napari_tiff_reader.py
+++ b/napari_tiff/napari_tiff_reader.py
@@ -75,7 +75,7 @@ def tifffile_reader(tif: TiffFile) -> List[LayerData]:
     if nlevels > 1:
         import zarr
         store = tif.aszarr(multiscales=True)
-        group = zarr.hierarchy.group(store=store)
+        group = zarr.group(store=store)
         data = [arr for _, arr in group.arrays()]  # read-only zarr arrays
         # assert array shapes are in descending order for napari multiscale image
         shapes = [arr.shape for arr in data]


### PR DESCRIPTION
See https://zarr.readthedocs.io/en/latest/user-guide/v3_migration.html for the migration guide
Could fix #41 