### PR TITLE
Pin supported zarr version before v3 migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
    'imagecodecs',
    'numpy',
    'tifffile>=2023.9.26',
-   'zarr',
+   'zarr>=2,<3',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This should fix #41 and is the recommended way to avoid any incompatibilities, before a proper migration to zarr 3.0 : https://zarr.readthedocs.io/en/latest/user-guide/v3_migration.html