### PR TITLE
Pin tifffile below 2025.5.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
    'imagecodecs',
    'numpy',
    # 2025.5.21 has moved to only zarr v3 for aszarr
-   'tifffile>=2023.9.26,<2025.5.21'
+   'tifffile>=2023.9.26,<2025.5.21',
    'zarr>=2,<3',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ requires-python = '>=3.10'
 dependencies = [
    'imagecodecs',
    'numpy',
-   'tifffile>=2023.9.26',
+   # 2025.5.21 has moved to only zarr v3 for aszarr
+   'tifffile>=2023.9.26,<2025.5.21'
    'zarr>=2,<3',
 ]
 


### PR DESCRIPTION
tifffile 2025.5.21 now requires zarr3 for aszarr functionality, see: https://github.com/cgohlke/tifffile/issues/297#issuecomment-2899801799
but it's not a drop-in replacement with the existing implementation.
As a result, we need to pin upper bound for the time being.

note that the linked thread indicates that performance with zarr3 is somewhat poor.