### PR TITLE
Support both zarr2/tifffile<2025.5.21 and zarr3/tifffile>2025.5.21

### DIFF
--- a/napari_tiff/napari_tiff_reader.py
+++ b/napari_tiff/napari_tiff_reader.py
@@ -9,7 +9,6 @@ see: https://napari.org/docs/plugins/hook_specifications.html
 Replace code below accordingly.  For complete documentation see:
 https://napari.org/docs/plugins/for_plugin_developers.html
 """
-
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from tifffile import TIFF, TiffFile, TiffSequence
@@ -75,8 +74,9 @@ def tifffile_reader(tif: TiffFile) -> List[LayerData]:
     if nlevels > 1:
         import zarr
         store = tif.aszarr(multiscales=True)
-        group = zarr.hierarchy.group(store=store)
-        data = [arr for _, arr in group.arrays()]  # read-only zarr arrays
+        group = zarr.open_group(store=store, mode='r')
+        # using group.attrs to get multiscales is recommended by cgohlke
+        data = [group[path_dict['path']] for path_dict in group.attrs['multiscales'][0]['datasets']]
         # assert array shapes are in descending order for napari multiscale image
         shapes = [arr.shape for arr in data]
         assert shapes == list(reversed(sorted(shapes)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,8 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-   'imagecodecs',
    'numpy',
-   'tifffile>=2023.9.26',
-   'zarr>=2,<3',
+   'tifffile[codecs, zarr]',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This is a replacement for PR pinning back tifffile, to work with zarr<3 (https://github.com/napari/napari-tiff/pull/47), or one pinning up tifffile, to work with zarr>3. Originally, I was going to do the latter here (hence branch name), but over in the tifffile repo,  cgohlke suggested using the attrs approach that works with both the zarr2 stores and zarr3 stores (the later lack the various list methods, so you get errors if you try to use `.arrays()` as before).
See: https://github.com/cgohlke/tifffile/issues/297#issuecomment-2906373547

I've tested this locally with a few ndpi as well as run tests--it works with both combinations.
Importantly, it works with py310, which isn't supported by zarr3, but is supported by napari.
In the issue linked above, there is an indication of performance regression with zarr3 and it does, subjectively, feel worse. But hopefully that is something that can be improved upstream.

In pyproject.toml I let tifffile sort out imagecodec and zarr versioning, which does move us up a bit in tifffile version, but as noted above, soon this will be moot as support for py310 is being dropped more broadly.

