### PR TITLE
Add function to get scale/units from vanilla tiff tags

### DIFF
--- a/src/napari_tiff/napari_tiff_metadata.py
+++ b/src/napari_tiff/napari_tiff_metadata.py
@@ -435,7 +435,14 @@ def get_time_units_seconds(value: float, unit: str = None) -> float:
 
 
 def get_scale_and_units_from_tiff(page, axes):
-    """Extract scale and units from TIFF tags using tifffile properties."""
+    """Extract scale and units from TIFF tags using tifffile properties.
+    
+    Notes
+    ----- 
+    - tiff tags XResolution and YResolution are pixels per ResolutionUnit in ImageWidth and ImageLength respectively
+    - tiff tags ResolutionUnit can be 1 (reserved; no unit), 2 (inch), or 3 (centimeter). However, tifffile uses meter as the default unit when ResolutionUnit is 1 (no unit); napari is fine with pixels
+    - tifffile has a helper `get_resolution` that returns pixels per  unit and handles basic unit conversions.
+    """
     scale_dict = {}
     units_dict = {}
 

--- a/src/napari_tiff/napari_tiff_metadata.py
+++ b/src/napari_tiff/napari_tiff_metadata.py
@@ -440,14 +440,16 @@ def get_scale_and_units_from_tiff(page, axes):
     Notes
     ----- 
     - tiff tags XResolution and YResolution are pixels per ResolutionUnit in ImageWidth and ImageLength respectively
-    - tiff tags ResolutionUnit can be 1 (reserved; no unit), 2 (inch), or 3 (centimeter). However, tifffile uses meter as the default unit when ResolutionUnit is 1 (no unit); napari is fine with pixels
+    - tiff tags ResolutionUnit can be 1 (reserved; no unit), 2 (inch), or 3 (centimeter). 
+    - tifffile treats ResolutionUnit=1 (no unit) as equivalent to meter when performing unit conversions via the unit parameter
     - tifffile has a helper `get_resolution` that returns pixels per  unit and handles basic unit conversions.
     """
     scale_dict = {}
     units_dict = {}
 
-    if page.resolutionunit == 1:
+    if page.resolutionunit == 1 or 282 not in page.tags:
         # 1 means no unit, but tifffile uses meter as the default
+        # 282 not in page.tags accounts for files that have missing resolution tags
         x_res, y_res = page.get_resolution()
         units_dict["X"] = "pixel"
         units_dict["Y"] = "pixel"


### PR DESCRIPTION
Partly addresses: https://github.com/napari/napari-tiff/issues/44
This PR uses `tifffile` API to get the x, y resolution (and the resolution unit) and convert to micron per pixel.
Tifffile is reading the tiff tags for this.


This was motivated by NDPI whole slide images (WSI), is based on looking at:
https://openslide.org/formats/hamamatsu/
https://www.loc.gov/preservation/digital/formats/content/tiff_tags.shtml
and tifffile API.
It should work for any tiff that uses tiff tags according to spec.

Added a set of simple tests that write tiffs with defined tiff tags for  X,YResolution and ResolutionUnit and then check that we get the expected napari scale and units.

Edit: in practice, for ndpi, this PR benefits from https://github.com/napari/napari-tiff/pull/45