### PR TITLE
Enh: Add parsing of scale/units from SVS files

### DIFF
--- a/src/napari_tiff/napari_tiff_metadata.py
+++ b/src/napari_tiff/napari_tiff_metadata.py
@@ -303,8 +303,8 @@ def get_svs_metadata(tif: TiffFile) -> dict[str, Any]:
     scale = svs_metadata.get('MPP') or 1.0
     unit = "µm"
     axes = tif.series[0].axes
-    metadata_kwargs["scale"] = tuple(scale if ax in ("X", "Y") else 1.0 for ax in axes if ax not in "CS")
-    metadata_kwargs["units"] = tuple(unit if ax in ("X", "Y") else "pixel" for ax in axes if ax not in "CS")
+    metadata_kwargs["scale"] = tuple(scale if ax in "XY" else 1.0 for ax in axes if ax not in "CS")
+    metadata_kwargs["units"] = tuple(unit if ax in "XY" else "pixel" for ax in axes if ax not in "CS")
 
     metadata_kwargs.setdefault("metadata", {}).update({"SVS_metadata": svs_metadata})
 

--- a/tests/test_tiff_metadata.py
+++ b/tests/test_tiff_metadata.py
@@ -155,11 +155,11 @@ def test_tifffile_reader_3d_resolution(tmp_path):
 
 
 def test_svs_resolution_units(tmp_path):
-    """Test tifffile_reader with 3D image with resolution unit."""
+    """Test tifffile_reader with SVS microns-per-pixel metadata."""
     data = np.zeros((10, 20), dtype=np.uint8)
-    filepath = tmp_path / "test.tiff"
+    filepath = tmp_path / "test.svs"
 
-    imwrite(filepath, data, description="Aperio |MPP = 1.234")
+    imwrite(filepath, data, description="Aperio |MPP = 1.234", tile=(16, 16))
 
     with TiffFile(filepath) as tif:
         assert tif.is_svs


### PR DESCRIPTION
Partly adresses: https://github.com/napari/napari-tiff/issues/44
This PR just uses the tifffile API to check if something is SVS and then get the SVS metadata to parse out scale (which is micron per pixel), set the units, and also put the rest of the metadata in layer.metadata.
I tested locally with a file from https://openslide.org/formats/aperio/
I also add a test that writes a TIFF with SVS-like metadata.