### PR TITLE
[ome-tiff] Use string hexes for color handling from ome-tiff to get napari colormaps when available

### DIFF
--- a/src/napari_tiff/napari_tiff_colormaps.py
+++ b/src/napari_tiff/napari_tiff_colormaps.py
@@ -13,6 +13,7 @@ def alpha_colormap(bitspersample=8, samples=4):
 
 
 def _int_to_rgba_bytes(intrgba: int) -> list[int]:
+    """Return RGBA bytes from a packed OME channel color integer."""
     signed = intrgba < 0
     rgba = list(intrgba.to_bytes(4, signed=signed, byteorder="big"))
     if rgba[-1] == 0:
@@ -21,8 +22,10 @@ def _int_to_rgba_bytes(intrgba: int) -> list[int]:
 
 
 def int_to_rgba(intrgba: int) -> tuple:
+    """Return normalized RGBA values from a packed OME channel color integer."""
     return tuple(x / 255 for x in _int_to_rgba_bytes(intrgba))
 
 
 def int_to_hex(intrgba: int) -> str:
+    """Return a ``#rrggbbaa`` string from a packed OME channel color integer."""
     return f"#{bytes(_int_to_rgba_bytes(intrgba)).hex()}"

--- a/src/napari_tiff/napari_tiff_colormaps.py
+++ b/src/napari_tiff/napari_tiff_colormaps.py
@@ -12,9 +12,17 @@ def alpha_colormap(bitspersample=8, samples=4):
     return {"name": "alpha",  "colors": alpha_cmap}
 
 
-def int_to_rgba(intrgba: int) -> tuple:
+def _int_to_rgba_bytes(intrgba: int) -> list[int]:
     signed = intrgba < 0
-    rgba = [x / 255 for x in intrgba.to_bytes(4, signed=signed, byteorder="big")]
+    rgba = list(intrgba.to_bytes(4, signed=signed, byteorder="big"))
     if rgba[-1] == 0:
-        rgba[-1] = 1
-    return tuple(rgba)
+        rgba[-1] = 255
+    return rgba
+
+
+def int_to_rgba(intrgba: int) -> tuple:
+    return tuple(x / 255 for x in _int_to_rgba_bytes(intrgba))
+
+
+def int_to_hex(intrgba: int) -> str:
+    return f"#{bytes(_int_to_rgba_bytes(intrgba)).hex()}"

--- a/src/napari_tiff/napari_tiff_metadata.py
+++ b/src/napari_tiff/napari_tiff_metadata.py
@@ -5,7 +5,7 @@ import numpy
 import numpy as np
 from tifffile import PHOTOMETRIC, TiffFile, xml2dict
 
-from napari_tiff.napari_tiff_colormaps import alpha_colormap, int_to_rgba, CUSTOM_COLORMAPS
+from napari_tiff.napari_tiff_colormaps import alpha_colormap, int_to_hex, CUSTOM_COLORMAPS
 
 
 def get_metadata(tif: TiffFile) -> dict[str, Any]:
@@ -352,7 +352,7 @@ def get_ome_tiff_metadata(tif: TiffFile) -> dict[str, Any]:
         color = channel.get("Color")
         colormap = None
         if color:
-            colormap = int_to_rgba(int(color))
+            colormap = int_to_hex(int(color))
         elif is_rgb and len(channels) > 1:
             # separate channels provided for RGB (with missing color)
             colormap = ["red", "green", "blue", alpha_colormap()][channel_idx]

--- a/tests/test_tiff_metadata.py
+++ b/tests/test_tiff_metadata.py
@@ -8,6 +8,7 @@ from base_data import (
     example_data_ometiff,
     imagej_hyperstack_image,
 )
+from napari_tiff.napari_tiff_colormaps import int_to_hex
 from napari_tiff.napari_tiff_metadata import get_extra_metadata, get_scale_and_units_from_ome
 from napari_tiff.napari_tiff_reader import tifffile_reader
 
@@ -93,3 +94,15 @@ def test_imagej_hyperstack_metadata(imagej_hyperstack_image):
 )
 def test_get_scale_and_units_from_ome(data, expected):
     assert get_scale_and_units_from_ome(**data) == expected
+
+
+@pytest.mark.parametrize(
+    ("intrgba", "expected"),
+    [
+        (0xFF000000, "#ff0000ff"),
+        (0x00FF0080, "#00ff0080"),
+        (-16776961, "#ff0000ff"),
+    ],
+)
+def test_int_to_hex(intrgba, expected):
+    assert int_to_hex(intrgba) == expected


### PR DESCRIPTION
napari checks string names (e.g. "magenta") and hex codes to see if the colormap is a napari colormap. It does not check RGBA tuples. So this PR just switches to using HEX for ome-tiff colors to get matching colormaps when possible and otherwise have the hex (better than 'unnamed').
It's the work of Codex with minor refactor from me.

Came up in a demo today, so I thought I would try to fix it.