### PR TITLE
Go back to pure zarr, effectively revert PR #45

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-   'dask[array]>=2021.10.0',
    'numpy',
    'tifffile[codecs, zarr]>=2024.7.21',
 ]

--- a/src/napari_tiff/napari_tiff_reader.py
+++ b/src/napari_tiff/napari_tiff_reader.py
@@ -9,7 +9,6 @@ see: https://napari.org/docs/plugins/hook_specifications.html
 Replace code below accordingly.  For complete documentation see:
 https://napari.org/docs/plugins/for_plugin_developers.html
 """
-import dask.array as da
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from tifffile import TIFF, TiffFile, TiffSequence
@@ -76,14 +75,14 @@ def tifffile_reader(tif: TiffFile) -> List[LayerData]:
         import zarr
         store = tif.aszarr(multiscales=True)
         group = zarr.open_group(store=store, mode='r')
+        # using group.attrs to get multiscales is recommended by cgohlke
         try:
             datasets = group.attrs['ome']['multiscales'][0]['datasets']
         except KeyError:
             datasets = group.attrs['multiscales'][0]['datasets']
 
-        # using group.attrs to get multiscales is recommended by cgohlke
-        # default dask chunk is 128MiB, so use 1 MiB, which is more reasonable for visualization
-        data = [da.from_zarr(group[path_dict['path']], chunks='1 MiB') for path_dict in datasets]
+        
+        data = [group[path_dict['path']] for path_dict in datasets]
         # assert array shapes are in descending order for napari multiscale image
         shapes = [arr.shape for arr in data]
         assert shapes == list(reversed(sorted(shapes)))

--- a/tests/test_tiff_reader.py
+++ b/tests/test_tiff_reader.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-import dask.array as da
+import zarr
 
 import pint
 from napari.layers import Image
@@ -120,7 +120,7 @@ def test_multiresolution_image(example_data_multiresolution):
     assert layer_data[0].shape == (16, 512, 512, 3)
     assert layer_data[1].shape == (16, 256, 256, 3)
     assert layer_data[2].shape == (16, 128, 128, 3)
-    assert all([isinstance(level, da.core.Array) for level in layer_data])
+    assert all([isinstance(level, zarr.Array) for level in layer_data])
 
 
 @pytest.mark.parametrize("file_name", ['test_imagej.tiff', 'test_ome.tiff', 'test_imagej_with_time.tiff', 'test_ome_with_time.tiff'])


### PR DESCRIPTION
Closes: https://github.com/napari/napari-tiff/issues/77

I did some more testing and I think this lighter approach is very compelling, at least for napari >0.6.6
(napari <0.7.0 really needs the dask)

Here's my tests with worst-case scenario file Hamamatsu-1.ndpi 
```
napari 0.7.1rc5  tifffile 2026.6.1  zarr 3.2.1
ROI 2000x2000 centered  repeats=10 warmup=2

level            shape               zarr              dask dask+cache (warm)
    0    101376x188160              33.39            117.42             16.00
    1      50688x94080              92.55            277.62             10.86
    2      25344x47040              88.39            369.64              6.18
    3      12672x23520             143.60            265.96              3.68
    4       6336x11760             246.38            786.99              4.39
    5        3168x5880               0.13              0.13              0.14
```
It's quite noticeable when using that zoom is just faster. It's really fast, you don't notice much of a lag at all, so honestly you don't feel the lack of cache -- but that should still be adressed in napari (https://github.com/napari/napari/issues/8976)

Here's a best case scenario CMU-1.svs (medium size, square 256 tiles)
```
napari 0.7.1rc5  tifffile 2026.6.1  zarr 3.2.1
ROI 2000x2000 centered  repeats=10 warmup=2

level            shape               zarr              dask dask+cache (warm)
    0      32914x46000              11.58             21.72              5.02
    1       8228x11500               9.97             16.41              3.64
    2        2057x2875               0.12              0.12              0.14
```
Both are blazing fast so we don't lose anything.

Script by Claude (fails on 0.6.6 due to slicing changes :sad:)
```
# /// script
# requires-python = ">3.11"
# dependencies = [
#     "napari==0.7.1rc5",
#     "tifffile[codecs,zarr]",
#     "dask[array]",
#     "zarr",
#     "numpy",
# ]
# ///
"""Benchmark napari multiscale slicing: pure zarr vs zarr-wrapped-in-dask.

Simulates zooming through a pyramidal TIFF/NDPI by requesting a 2000x2000
centered region from each pyramid level, driving napari's real slicing
machinery (see napari-tiff issue #77).

    uv run bench_zarr_vs_dask.py /path/to/Hamamatsu-1.ndpi

Backends:
  zarr               pure zarr arrays from tifffile.aszarr (no cache)
  dask               da.from_zarr(..., chunks='1 MiB'), napari cache off;
                     every read is a miss -> the cost of zooming to a NEW region
  dask+cache (warm)  cache on, repeats re-read the same region -> revisit hit
"""
import sys
import time
from statistics import median

import numpy as np
import tifffile
import zarr
import dask.array as da
from napari.layers import Image
from napari.components import Dims

ROI, REPEATS, WARMUP = 2000, 10, 2


def slice_once(layer, dims):
    """One synchronous slice through napari's real machinery."""
    req = layer._slicing_state._make_slice_request(dims)
    return req()  # the read: data[corner_slice] -> np.asarray


def bench(layer, dims, level, shape):
    """Median ms to slice a centered ROI at `level`."""
    h, w = shape[0], shape[1]
    oy, ox = (h - min(ROI, h)) // 2, (w - min(ROI, w)) // 2
    corners = np.zeros((2, layer.ndim), dtype=int)
    corners[0] = [oy, ox]
    corners[1] = [oy + min(ROI, h) - 1, ox + min(ROI, w) - 1]
    layer._data_level, layer.corner_pixels = level, corners

    times = []
    for i in range(WARMUP + REPEATS):
        t0 = time.perf_counter()
        slice_once(layer, dims)
        if i >= WARMUP:
            times.append((time.perf_counter() - t0) * 1e3)
    return median(times)


def main(path):
    tif = tifffile.TiffFile(path)
    group = zarr.open_group(tif.aszarr(multiscales=True), mode="r")
    attrs = group.attrs
    ms = attrs["ome"]["multiscales"] if "ome" in attrs else attrs["multiscales"]
    arrays = [group[d["path"]] for d in ms[0]["datasets"]]
    shapes = [a.shape for a in arrays]
    dask_arrays = [da.from_zarr(a, chunks="1 MiB") for a in arrays]

    print(f"{path}\nnapari {__import__('napari').__version__}  "
          f"tifffile {tifffile.__version__}  zarr {zarr.__version__}")
    print(f"ROI {ROI}x{ROI} centered  repeats={REPEATS} warmup={WARMUP}\n")

    # (label, data, cache_on)
    runs = [
        ("zarr", arrays, False),
        ("dask", dask_arrays, False),
        ("dask+cache (warm)", dask_arrays, True),
    ]
    cols = {}
    for label, data, cache in runs:
        layer = Image(data, multiscale=True, rgb=True, cache=cache)
        dims = Dims(ndim=layer.ndim, ndisplay=2)
        cols[label] = [bench(layer, dims, lvl, shapes[lvl])
                       for lvl in range(len(data))]

    labels = list(cols)
    print(f"{'level':>5} {'shape':>16} " + "".join(f"{l:>18}" for l in labels))
    for lvl in range(len(arrays)):
        s = f"{shapes[lvl][0]}x{shapes[lvl][1]}"
        print(f"{lvl:>5} {s:>16} "
              + "".join(f"{cols[l][lvl]:>18.2f}" for l in labels))


if __name__ == "__main__":
    if len(sys.argv) != 2:
        sys.exit("usage: uv run bench_zarr_vs_dask.py <image.ndpi>")
    main(sys.argv[1])
```