### PR TITLE
Ensure we can read '*.ome.tiff' extension

### DIFF
--- a/src/napari_tiff/napari.yaml
+++ b/src/napari_tiff/napari.yaml
@@ -14,6 +14,7 @@ contributions:
     - '*.zip'
     - '*.tiff'
     - '*.tif'
+    - '*.ome.tiff'
     - '*.ome.tif'
     - '*.lsm'
     - '*.stk'


### PR DESCRIPTION
According to the spec:
-  https://ome-model.readthedocs.io/en/stable/ome-tiff/specification.html
both ome.tiff and ome.tif are valid. Adding ome.tiff to ensure we can read files properly.